### PR TITLE
flake8 fix: var used before init

### DIFF
--- a/sthype/classes/spatial_temporal_graph.py
+++ b/sthype/classes/spatial_temporal_graph.py
@@ -540,6 +540,7 @@ class SpatialTemporalGraph(nx.Graph):
                 edges = self.get_initial_edge_edges(*initial_edge)
                 activation = self[edges[0][0]][edges[0][1]]["post_hyperedge_activation"]
                 begin = edges[0][0]
+                end = edges[0][1]
                 pixels: list[Point] = [self.positions[begin]]
                 attributes = {}
                 for node1, node2 in edges:


### PR DESCRIPTION
## Description

var `end` used before init

## Implementation

init end before usage